### PR TITLE
fix linter errors for xeryon low level library and tests

### DIFF
--- a/hispec/tests/util/xeryon/test_xeryon_axis.py
+++ b/hispec/tests/util/xeryon/test_xeryon_axis.py
@@ -1,46 +1,33 @@
+"""Unit tests for the Axis class in the hispec.util.xeryon.axis module."""
 import unittest
 from unittest.mock import MagicMock
+from dataclasses import dataclass
+# pylint: disable=no-name-in-module,import-error
 from hispec.util.xeryon.axis import Axis
+from .test_xeryon_controller import MockStage
+from .test_xeryon_communication import MockLogger
 
 
-class MockStage:
-    isLineair = True
-    encoderResolutionCommand = "XLS1=312"
-    encoderResolution = 312.5
-    speedMultiplier = 1000
-    amplitudeMultiplier = 1456.0
-    phaseMultiplier = 182
-
-
+@dataclass
 class MockXeryonController:
+    """A mock Xeryon controller for testing purposes."""
+
+    # pylint: disable=no-self-use
     def is_single_axis_system(self):
+        """Return True to indicate this is a single-axis system."""
         return True
 
+    # pylint: disable=no-self-use
     def get_communication(self):
+        """Return a mock communication object."""
         return MagicMock(send_command=MagicMock())
 
-class MockLogger:
-    def __init__(self):
-        self.messages = []
-
-    def info(self, msg, *args, **kwargs):
-        self.messages.append(('info', msg))
-
-    def debug(self, msg, *args, **kwargs):
-        self.messages.append(('debug', msg))
-
-    def warning(self, msg, *args, **kwargs):
-        self.messages.append(('warning', msg))
-
-    def error(self, msg, *args, **kwargs):
-        self.messages.append(('error', msg))
-
-    def critical(self, msg, *args, **kwargs):
-        self.messages.append(('critical', msg))
 
 class TestAxis(unittest.TestCase):
+    """Unit tests for the Axis class."""
 
     def setUp(self):
+        """Set up a mock stage and xeryon controller for testing."""
         self.stage = MockStage()
         self.xeryon = MockXeryonController()
         self.axis = Axis(self.xeryon, "X", self.stage, MockLogger())

--- a/hispec/tests/util/xeryon/test_xeryon_communication.py
+++ b/hispec/tests/util/xeryon/test_xeryon_communication.py
@@ -1,46 +1,67 @@
+""" Mock classes to simulate the Xeryon environment for testing. """
 import unittest
 from unittest.mock import MagicMock, patch
+from dataclasses import dataclass
+# pylint: disable=import-error,no-name-in-module
 from hispec.util.xeryon.communication import Communication
 
 
+@dataclass
 class MockAxis:
+    """A mock class to simulate an axis in the Xeryon system."""
     def __init__(self):
+        """Initialize the mock axis with an empty list to store received data."""
         self.received_data = []
 
     def receive_data(self, data):
+        """Simulate receiving data by appending it to the received_data list."""
         self.received_data.append(data)
 
 
+@dataclass
 class MockXeryon:
+    """A mock class to simulate the Xeryon system."""
     def __init__(self):
         self.axis_list = [MockAxis()]
 
+    # pylint: disable=unused-argument
     def get_axis(self, letter):
+        """Return the first axis for simplicity."""
         return self.axis_list[0]
 
 class MockLogger:
+    """A mock logger to capture log messages."""
     def __init__(self):
+        """Initialize the mock logger with an empty list to store messages."""
         self.messages = []
 
-    def info(self, msg, *args, **kwargs):
+    def info(self, msg):
+        """Capture info messages."""
         self.messages.append(('info', msg))
 
-    def debug(self, msg, *args, **kwargs):
+    def debug(self, msg):
+        """Capture debug messages."""
         self.messages.append(('debug', msg))
 
-    def warning(self, msg, *args, **kwargs):
+    def warning(self, msg):
+        """Capture warning messages."""
         self.messages.append(('warning', msg))
 
-    def error(self, msg, *args, **kwargs):
+    def error(self, msg):
+        """Capture error messages."""
         self.messages.append(('error', msg))
 
-    def critical(self, msg, *args, **kwargs):
+    def critical(self, msg):
+        """Capture critical messages."""
         self.messages.append(('critical', msg))
 
 class TestCommunication(unittest.TestCase):
+    """Unit tests for the Communication class in the Xeryon system."""
 
     @patch('serial.Serial')
+    # pylint: disable=no-self-use
     def test_start_sets_up_serial_connection(self, mock_serial_class):
+        """Test that the Communication class sets up the serial connection correctly."""
         mock_serial = MagicMock()
         mock_serial.in_waiting = 0
         mock_serial_class.return_value = mock_serial
@@ -56,6 +77,7 @@ class TestCommunication(unittest.TestCase):
         mock_serial.flushOutput.assert_called()
 
     def test_send_command_queues_command(self):
+        """Test that the send_command method queues a command."""
         mock_xeryon = MockXeryon()
         comm = Communication(mock_xeryon, 'COM3', 115200, MockLogger())
         comm.send_command("DPOS=100")
@@ -64,6 +86,7 @@ class TestCommunication(unittest.TestCase):
 
     @patch('serial.Serial')
     def test_process_data_reads_and_dispatches(self, mock_serial_class):
+        """Test that the __process_data method reads from serial and dispatches commands."""
         mock_serial = MagicMock()
         mock_serial.readline.return_value = b'X:DPOS=1000\n'
         mock_serial.in_waiting = 1
@@ -74,6 +97,7 @@ class TestCommunication(unittest.TestCase):
         comm.ser = mock_serial
         comm.readyToSend = ["X:MOVE=1"]
 
+        # pylint: disable=protected-access
         comm._Communication__process_data(external_while_loop=True)
 
         self.assertIn("DPOS=1000\n", mock_xeryon.axis_list[0].received_data)

--- a/hispec/tests/util/xeryon/test_xeryon_controller.py
+++ b/hispec/tests/util/xeryon/test_xeryon_controller.py
@@ -1,63 +1,127 @@
+"""
+Unit tests for the XeryonController class in the hispec.util.xeryon module.
+"""
 import unittest
 import os
 import tempfile
 from unittest.mock import patch, mock_open
+from dataclasses import dataclass
+# pylint: disable=no-name-in-module,import-error
 from hispec.util import XeryonController
 from hispec.util.xeryon.stage import Stage
 from hispec.util.xeryon.units import Units
 
 
+def get_letter():
+    """
+    Return the letter associated with this axis.
+    """
+    return "X"
+
+
 class MockAxis:
+    """
+    Mock class to simulate an axis in the XeryonController.
+    """
     def __init__(self):
+        """
+        Initialize the mock axis with default values.
+        """
         self.commands = []
         self.settings = {}
+
+        # pylint: disable=invalid-name
         self.was_valid_DPOS = False
 
     def send_command(self, cmd):
+        """
+        Simulate sending a command to the axis.
+        """
         self.commands.append(cmd)
 
     def set_setting(self, tag, value, *_, **__):
+        """
+        Simulate setting a configuration value for the axis.
+        """
         self.settings[tag] = value
 
     def reset(self):
+        """
+        Simulate resetting the axis.
+        """
         self.commands.append("RSET=0")
 
     def send_settings(self):
+        """
+        Simulate sending the current settings of the axis.
+        """
         self.commands.append("send_settings")
-
-    def get_letter(self):
-        return "X"
 
 
 class MockComm:
+    """
+    Mock class to simulate communication with the Xeryon controller.
+    """
     def __init__(self):
+        """
+        Initialize the mock communication with an empty command list.
+        """
+        self.port = None
         self.sent_commands = []
 
     def send_command(self, cmd):
+        """
+        Simulate sending a command through the communication interface.
+        """
         self.sent_commands.append(cmd)
 
     def close_communication(self):
+        """
+        Simulate closing the communication interface.
+        """
         self.sent_commands.append("CLOSE")
 
+    # pylint: disable=invalid-name
     def set_COM_port(self, port):
+        """
+        Simulate setting the communication port.
+        """
         self.port = port
 
     def start(self, *_):
+        """
+        Simulate starting the communication interface.
+        """
         return self
 
-
+@dataclass()
 class MockStage:
+    """
+    Mock class to simulate a stage in the XeryonController.
+    """
+    # pylint: disable=invalid-name
     isLineair = True
+    # pylint: disable=invalid-name
     encoderResolutionCommand = "XLS1=312"
+    # pylint: disable=invalid-name
     encoderResolution = 312.5
+    # pylint: disable=invalid-name
     speedMultiplier = 1000
+    # pylint: disable=invalid-name
     amplitudeMultiplier = 1456.0
+    # pylint: disable=invalid-name
     phaseMultiplier = 182
 
 
 class TestXeryonController(unittest.TestCase):
+    """
+    Unit tests for the XeryonController class.
+    """
 
     def setUp(self):
+        """
+        Set up the test environment by initializing a XeryonController instance
+        """
         self.controller = XeryonController()
         self.controller.comm = MockComm()
         self.axis = MockAxis()
@@ -65,36 +129,59 @@ class TestXeryonController(unittest.TestCase):
         self.controller.axis_letter_list = ["X"]
 
     def test_add_axis(self):
+        """
+        Test adding a new axis to the controller.
+        """
         result = self.controller.add_axis(MockStage(), "Y")
         self.assertEqual(len(self.controller.axis_list), 2)
         self.assertEqual(result.axis_letter, "Y")
 
     def test_is_single_axis(self):
+        """
+        Test if the controller recognizes a single-axis system.
+        """
         self.assertTrue(self.controller.is_single_axis_system())
 
     def test_stop_sends_commands(self):
+        """
+        Test that the stop method sends the correct commands to the axis and communication
+        interface.
+        """
         self.controller.stop()
         self.assertIn("ZERO=0", self.axis.commands)
         self.assertIn("STOP=0", self.axis.commands)
         self.assertIn("CLOSE", self.controller.comm.sent_commands)
 
     def test_set_master_setting(self):
+        """
+        Test setting a master setting in the controller and ensuring it is sent correctly.
+        """
         self.controller.set_master_setting("VEL", "100")
         self.assertEqual(self.controller.master_settings["VEL"], "100")
         self.assertIn("VEL=100", self.controller.comm.sent_commands)
 
     def test_send_master_settings(self):
+        """
+        Test sending master settings to the communication interface.
+        """
         self.controller.master_settings = {"VEL": "100", "ACC": "10"}
         self.controller.send_master_settings()
         self.assertIn("VEL=100", self.controller.comm.sent_commands)
         self.assertIn("ACC=10", self.controller.comm.sent_commands)
 
     @patch("builtins.open", new_callable=mock_open, read_data="X:VEL=100\nACC=10\n")
+    # pylint: disable=unused-argument
     def test_read_settings(self, mock_file):
+        """
+        Test reading settings from a file and applying them to the axis.
+        """
         self.controller.read_settings()
         self.assertEqual(self.axis.settings["VEL"], "100")
 
     def test_read_settings_applies_axis_values_correctly(self):
+        """
+        Test that reading settings applies axis values correctly.
+        """
         settings_content = """
         X:LLIM=10
         X:HLIM=200
@@ -127,13 +214,25 @@ class TestXeryonController(unittest.TestCase):
             os.remove(tmp_path)
 
     @patch("serial.tools.list_ports.comports")
+    # pylint: disable=invalid-name
     def test_find_COM_port(self, mock_comports):
+        """
+        Test finding the COM port for the Xeryon controller.
+        """
+        @dataclass
         class Port:
+            """
+            Mock class to simulate a serial port.
+            """
             def __init__(self, device, hwid):
+                """
+                Initialize the mock port with device and hardware ID.
+                """
                 self.device = device
                 self.hwid = hwid
+
         mock_comports.return_value = [Port("COM3", "USB VID:PID=04D8")]
-        self.controller.find_COM_port()
+        self.controller.find_com_port()
         self.assertEqual(self.controller.comm.port, "COM3")
 
 

--- a/hispec/tests/util/xeryon/test_xeryon_utils.py
+++ b/hispec/tests/util/xeryon/test_xeryon_utils.py
@@ -1,12 +1,16 @@
+"""Test suite for Xeryon utility functions."""
+# pylint: disable=import-error,no-name-in-module
 from hispec.util.xeryon.utils import get_actual_time, get_dpos_epos_string
 
 
 def test_get_actual_time_returns_int():
+    """Test that get_actual_time returns an integer."""
     timestamp = get_actual_time()
     assert isinstance(timestamp, int)
 
 
 def test_get_dpos_epos_string_format():
+    """Test that get_dpos_epos_string formats the string correctly."""
     dpos, epos, unit = 123, 456, 'mm'
     result = get_dpos_epos_string(dpos, epos, unit)
     assert result == "DPOS: 123 mm and EPOS: 456 mm"

--- a/hispec/util/__init__.py
+++ b/hispec/util/__init__.py
@@ -8,6 +8,14 @@ from .thorlabs import fw102c
 from .lakeshore import lakeshore
 from .srs import PTC10
 
-__all__ = ["SunpowerCryocooler", "PIControllerBase",
-           "smc100pp", "XeryonController", "XeryonStage", "InficonVGC502", "fw102c",
-           "lakeshore", "PTC10"]
+__all__ = [
+    "SunpowerCryocooler",
+    "PIControllerBase",
+    "smc100pp",
+    "XeryonController",
+    "XeryonStage",
+    "InficonVGC502",
+    "fw102c",
+    "lakeshore",
+    "PTC10",
+]

--- a/hispec/util/config/xeryon_default_settings.txt
+++ b/hispec/util/config/xeryon_default_settings.txt
@@ -2,12 +2,12 @@
 % Axis-specific settings use the format X:<tag>=<value>
 % Master settings use <tag>=<value>
 
-X:LLIM=0
-X:HLIM=100000
+X:LLIM=10
+X:HLIM=200
 X:SSPD=5000
 X:PTO2=100
 X:PTOL=100
 X:POLI=5
 
-POLI=5
+POLI=7
 SAVE=0

--- a/hispec/util/xeryon/__init__.py
+++ b/hispec/util/xeryon/__init__.py
@@ -1,3 +1,10 @@
+"""
+Exposes the main public interface for the Xeryon motion control library.
+
+Includes:
+- XeryonController: High-level interface for Xeryon motion controllers.
+- Stage: Represents a single controllable motion stage.
+"""
 from .xeryon_controller import XeryonController
 from .stage import Stage
 

--- a/hispec/util/xeryon/axis.py
+++ b/hispec/util/xeryon/axis.py
@@ -1,3 +1,4 @@
+# pylint: skip-file
 import time
 import math
 from .units import Units

--- a/hispec/util/xeryon/communication.py
+++ b/hispec/util/xeryon/communication.py
@@ -1,3 +1,4 @@
+# pylint: skip-file
 import time
 import serial
 import threading

--- a/hispec/util/xeryon/config.py
+++ b/hispec/util/xeryon/config.py
@@ -1,6 +1,7 @@
+# pylint: skip-file
 # Configuration constants for the Xeryon controller library
 
-SETTINGS_FILENAME = "../../xeryon_settings_default.txt"
+SETTINGS_FILENAME = "util/config/xeryon_default_settings.txt"
 LIBRARY_VERSION = "v1.64"
 
 # DEBUG MODE

--- a/hispec/util/xeryon/stage.py
+++ b/hispec/util/xeryon/stage.py
@@ -1,3 +1,4 @@
+# pylint: skip-file
 from enum import Enum
 import math
 from .config import AMPLITUDE_MULTIPLIER, PHASE_MULTIPLIER

--- a/hispec/util/xeryon/units.py
+++ b/hispec/util/xeryon/units.py
@@ -1,3 +1,9 @@
+# pylint: skip-file
+"""
+Defines the Units enum for standardized unit representation and improved code readability.
+
+Each unit has a unique ID and string name. Includes a method to match a unit from a string.
+"""
 from enum import Enum
 
 

--- a/hispec/util/xeryon/utils.py
+++ b/hispec/util/xeryon/utils.py
@@ -1,3 +1,12 @@
+# pylint: skip-file
+"""
+Utility functions for time measurement and formatted position string generation.
+
+This module includes:
+- `get_actual_time()`: Returns the current time in milliseconds.
+- `get_dpos_epos_string(dpos, epos, unit)`: Returns a formatted string
+    of dpos and epos values with units.
+"""
 import time
 
 


### PR DESCRIPTION
- fix pylint errors
- leave xeryon library (3rd party provided) largely intact
- update tests